### PR TITLE
chore: use `main` branch in az devops status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Arcus - Machine Learning
-[![Build Status](https://dev.azure.com/codit/Arcus/_apis/build/status/arcus-azure.arcus.ml?branchName=master)](https://dev.azure.com/codit/Arcus/_build/latest?definitionId=836&branchName=master) [![PyPI version](https://badge.fury.io/py/arcus-ml.svg)](https://badge.fury.io/py/arcus-ml)
+[![Build Status](https://dev.azure.com/codit/Arcus/_apis/build/status/arcus-azure.arcus.ml?branchName=main)](https://dev.azure.com/codit/Arcus/_build/latest?definitionId=836&branchName=main) [![PyPI version](https://badge.fury.io/py/arcus-ml.svg)](https://badge.fury.io/py/arcus-ml)
 
 Python Machine Learning development in a breeze.
 


### PR DESCRIPTION
Use default `main` branch in Azure DevOps status badge.